### PR TITLE
fix: use momentjs instead of date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "command-exists": "^1.2.8",
     "copy-to-clipboard": "^3.2.0",
     "cors": "^2.8.5",
-    "date-fns": "^2.0.1",
     "express": "^4.17.1",
     "express-ws": "^4.0.0",
     "geoip-lite": "^1.3.7",

--- a/src/v2/stores/networkOverview.js
+++ b/src/v2/stores/networkOverview.js
@@ -7,7 +7,7 @@ import {
   observe,
   computed,
 } from 'mobx';
-import {parse, format} from 'date-fns';
+import moment from 'moment';
 import {
   map,
   keys,
@@ -73,7 +73,7 @@ class OverviewStore {
       map(([date, value = 0]) => ({
         y: Math.round((parseFloat(value) / 60) * 100) / 100,
         x: date,
-        date: format(parse(date), 'MMM D hh:mmA'),
+        date: moment(date, 'YYYYMMDDTHH:mm', true).format('MMM D hh:mmA'),
       })),
       toPairs,
       pickBy(identity),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5293,11 +5293,6 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.1.tgz#c5f30e31d3294918e6b6a82753a4e719120e203d"
-  integrity sha512-C14oTzTZy8DH1Eq8N78owrCWvf3+cnJw88BTK/N3DYWVxDJuJzPaNdplzYxDYuuXXGvqBcO4Vy5SOrwAooXSWw==
-
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"


### PR DESCRIPTION
Problem:

* date-fns introduced a major version bump that dependabot picked up
* we're only using it in one place

Solution:

* let's go back to our old friend moment.js since we're using it elsewhere
