### PR TITLE
fix: broken v1 routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -236,7 +236,7 @@ class App extends Component {
 
     if (location.pathname !== '/') {
       let pathMatch = matchPath(window.location.pathname, {
-        path: '/:type/:id',
+        path: '/v1/:type/:id',
         exact: false,
         strict: false,
       });
@@ -579,102 +579,100 @@ class App extends Component {
 
     return (
       <MuiThemeProvider theme={themeV1}>
-        <Router history={history}>
-          <CssBaseline />
-          <div className="App">
-            <BxAppBarThemed
-              handleSearch={self.handleSearch(self)}
-              enabled={this.state.enabled}
-              handleSwitch={this.toggleEnabled(self)}
-              handleSetEndpointName={this.setEndpointName}
-              handleMap={this.showMap(self)}
-            />
-            <div>
-              <Route
-                path="/map"
-                render={() => (
-                  <BxDialogWorldMapThemed
-                    open={true}
-                    onClose={self.handleDialogClose}
-                    nodes={this.state.nodes}
-                    leaderId={leaderId}
-                  />
-                )}
-              />
-              <Route
-                path="/txn/:id"
-                exact
-                render={() => (
-                  <BxDialogThemed
-                    selectedValue={self.state.selectedValue}
-                    open={self.state.dialogOpen}
-                    onClose={self.handleDialogClose}
-                  />
-                )}
-              />
-              <Route
-                path="/blk/:id"
-                exact
-                render={() => (
-                  <BxDialogThemed
-                    selectedValue={self.state.selectedValue}
-                    open={self.state.dialogOpen}
-                    onClose={self.handleDialogClose}
-                  />
-                )}
-              />
-              <Route
-                path="/ent/:id"
-                exact
-                render={() => (
-                  <BxDialogThemed
-                    selectedValue={self.state.selectedValue}
-                    open={self.state.dialogOpen}
-                    onClose={self.handleDialogClose}
-                  />
-                )}
-              />
-              <Route
-                path="/txns-by-prgid/:id"
-                exact
-                render={() => (
-                  <BxDialogTransactionsThemed
-                    selectedValue={self.state.selectedValue}
-                    open={self.state.dialogOpen}
-                    onClose={self.handleDialogClose}
-                  />
-                )}
-              />
-            </div>
-            <p />
-            <BxStatsTableThemed
-              globalStats={this.state.globalStats}
-              nodeCount={this.state.nodes.length}
-              feeCalculator={this.state.feeCalculator}
-            />
-            <p />
-            <BxTransactionChartThemed txnStats={this.state.txnStats} />
-            <p />
-            <Grid container spacing={1} justify="center">
-              <Grid item style={{width: '1460px'}}>
-                <BxDataTableThemed
-                  dataType="blk"
-                  dataItems={this.state.blocks}
+        <CssBaseline />
+        <div className="App">
+          <BxAppBarThemed
+            handleSearch={self.handleSearch(self)}
+            enabled={this.state.enabled}
+            handleSwitch={this.toggleEnabled(self)}
+            handleSetEndpointName={this.setEndpointName}
+            handleMap={this.showMap(self)}
+          />
+          <div>
+            <Route
+              path="/map"
+              render={() => (
+                <BxDialogWorldMapThemed
+                  open={true}
+                  onClose={self.handleDialogClose}
+                  nodes={this.state.nodes}
+                  leaderId={leaderId}
                 />
-              </Grid>
-            </Grid>
-            <p />
-            <Grid container spacing={1} justify="center">
-              <Grid item style={{width: '1460px'}}>
-                <BxDataTableThemed
-                  dataType="txn"
-                  dataItems={this.state.transactions}
+              )}
+            />
+            <Route
+              path="/txn/:id"
+              exact
+              render={() => (
+                <BxDialogThemed
+                  selectedValue={self.state.selectedValue}
+                  open={self.state.dialogOpen}
+                  onClose={self.handleDialogClose}
                 />
-              </Grid>
-            </Grid>
-            <p />
+              )}
+            />
+            <Route
+              path="/blk/:id"
+              exact
+              render={() => (
+                <BxDialogThemed
+                  selectedValue={self.state.selectedValue}
+                  open={self.state.dialogOpen}
+                  onClose={self.handleDialogClose}
+                />
+              )}
+            />
+            <Route
+              path="/ent/:id"
+              exact
+              render={() => (
+                <BxDialogThemed
+                  selectedValue={self.state.selectedValue}
+                  open={self.state.dialogOpen}
+                  onClose={self.handleDialogClose}
+                />
+              )}
+            />
+            <Route
+              path="/txns-by-prgid/:id"
+              exact
+              render={() => (
+                <BxDialogTransactionsThemed
+                  selectedValue={self.state.selectedValue}
+                  open={self.state.dialogOpen}
+                  onClose={self.handleDialogClose}
+                />
+              )}
+            />
           </div>
-        </Router>
+          <p />
+          <BxStatsTableThemed
+            globalStats={this.state.globalStats}
+            nodeCount={this.state.nodes.length}
+            feeCalculator={this.state.feeCalculator}
+          />
+          <p />
+          <BxTransactionChartThemed txnStats={this.state.txnStats} />
+          <p />
+          <Grid container spacing={1} justify="center">
+            <Grid item style={{width: '1460px'}}>
+              <BxDataTableThemed
+                dataType="blk"
+                dataItems={this.state.blocks}
+              />
+            </Grid>
+          </Grid>
+          <p />
+          <Grid container spacing={1} justify="center">
+            <Grid item style={{width: '1460px'}}>
+              <BxDataTableThemed
+                dataType="txn"
+                dataItems={this.state.transactions}
+              />
+            </Grid>
+          </Grid>
+          <p />
+        </div>
       </MuiThemeProvider>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,10 @@ const AppV2 = lazy(() => import('./AppV2'));
 
 async function main() {
   await EndpointConfig.load();
+  const renderV1 = window.location.pathname.startsWith('/v1');
   ReactDOM.render(
-    <BrowserRouter>
-      {window.location.pathname.startsWith('/v1') ? (
+    <BrowserRouter basename={renderV1 ? '/v1' : null}>
+      {renderV1 ? (
         <App />
       ) : (
         <Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
- The path matcher was broken because it did not expect the `/v1` path
- The router was broken for a similar reason
- I took out the `<Router>` component because it seems to me that the root `<BrowserRouter>` already manages history and the `<Router>` component was interfering with the basename property that I set in `<BrowserRouter>`

This change was motivated by the lack of transaction support in v2, we still want to link to transaction details in the example apps and so must use v1 still