### PR TITLE
fix: make multiple accounts warning more fault-tolerant

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -580,17 +580,12 @@ async function getClusterInfo() {
       continue;
     }
     if (node.votePubkey && node.votePubkey != votePubkey) {
-      if (node.warning && node.warning.hasMultipleVoteAccounts) {
-        node.warning.hasMultipleVoteAccounts.push(
-          voteAccount.authorizedVoterPubkey,
-        );
-      } else {
-        node.warning |= {};
-        node.warning.hasMultipleVoteAccounts = [
-          node.votePubkey,
-          voteAccount.authorizedVoterPubkey,
-        ];
-      }
+      node.warning |= {};
+      node.warning.hasMultipleVoteAccounts |= {};
+      node.warning.hasMultipleVoteAccounts[node.votePubkey] |= {};
+      node.warning.hasMultipleVoteAccounts[node.votePubkey][
+        voteAccount.authorizedVoterPubkey
+      ] = true;
       continue;
     }
     node.nodePubkey = nodePubkey;


### PR DESCRIPTION
Problem:

* also/tangential: bug in node warning for multiple vote accounts

Solution:

* code the warning storage in a more forgiving manner