### PR TITLE
fix: warning for multiple vote accounts

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -580,9 +580,9 @@ async function getClusterInfo() {
       continue;
     }
     if (node.votePubkey && node.votePubkey != votePubkey) {
-      node.warning |= {};
-      node.warning.hasMultipleVoteAccounts |= {};
-      node.warning.hasMultipleVoteAccounts[node.votePubkey] |= {};
+      node.warning = (node.warning || {});
+      node.warning.hasMultipleVoteAccounts = (node.warning.hasMultipleVoteAccounts || {});
+      node.warning.hasMultipleVoteAccounts[node.votePubkey] = (node.warning.hasMultipleVoteAccounts[node.votePubkey] || {});
       node.warning.hasMultipleVoteAccounts[node.votePubkey][
         voteAccount.authorizedVoterPubkey
       ] = true;


### PR DESCRIPTION
Problem:

* JS |= semantics

Solution:

* do it the old-fashioned way for now