### PR TITLE
feat: add force=true parameter to force TdS page display

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "lint-staged": "^9.4.1",
     "moment": "^2.24.0",
     "prettier": "^1.18.2",
+    "query-string": "^6.1.0",
     "qrcode.react": "^0.9.3",
     "react": "^16.10.1",
     "react-app-rewired": "^2.1.3",

--- a/src/v2/components/TourDeSol/index.jsx
+++ b/src/v2/components/TourDeSol/index.jsx
@@ -8,6 +8,7 @@ import SectionHeader from 'v2/components/UI/SectionHeader';
 import OverviewStore from 'v2/stores/networkOverview';
 import {TDS_ACTIVE_STAGE, TDS_STAGES, SLOTS_PER_DAY} from 'v2/constants';
 import socketActions from 'v2/stores/socket';
+import {parse as queryParse} from 'query-string';
 
 import Ranking from './Ranking';
 import Stage from './Stage';
@@ -15,10 +16,11 @@ import Table from './Table';
 import Cards from './Cards';
 import useStyles from './styles';
 
-const TourDeSol = ({history}: {history: RouterHistory}) => {
+const TourDeSol = ({history, location}: {history: RouterHistory, location: Location}) => {
   const {endpointName} = socketActions;
+  const queryParams = queryParse(location.search);
   useEffect(() => {
-    if (!eq('tds', endpointName)) {
+    if (!eq('tds', endpointName) && !eq('true', queryParams.force)) {
       history.replace(`/`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Problem:

* we'd like to be able to see TdS-style ranking when TdS network is unavailable

Solution:

* add a "force=true" query parameter to force display of the TdS page
