### PR TITLE
fix: marker showing pubkey if no name specified

### DIFF
--- a/src/v2/stores/nodes.js
+++ b/src/v2/stores/nodes.js
@@ -53,7 +53,7 @@ class Store {
         pubkey,
         gossip,
         coordinates,
-        name: (identity && identity.name) || 'Unknown',
+        name: (identity && identity.name) || identity.pubkey,
         avatarUrl: (identity && identity.avatarUrl) || '',
       })),
       filter({what: 'Validator'}),


### PR DESCRIPTION
Fixes #523 