### PR TITLE
feat: better error messages by using util.inspect

### DIFF
--- a/api/friendlyGet.js
+++ b/api/friendlyGet.js
@@ -1,3 +1,4 @@
+import util from 'util';
 import _ from 'lodash';
 import allSettled from 'promise.allsettled';
 
@@ -57,7 +58,7 @@ export class FriendlyGet {
 
     if (_.size(__errors__) > 0) {
       compactResult.__errors__ = __errors__;
-      console.warn('FRIENDLY_GET_HAD_PROBLEMS', JSON.stringify(__errors__));
+      console.warn('FRIENDLY_GET_HAD_PROBLEMS', util.inspect(__errors__));
     }
 
     return compactResult;


### PR DESCRIPTION
PROBLEM:

* error data structure can apparently be circular sometimes 🌎 

SOLUTION:

* use `util.inspect` instead of `JSON.stringify` to flatten things out 💌 

