### PR TITLE
feat: handle mapmarker errors, empty leader tooltip

### DIFF
--- a/src/v2/components/Dashboard/NetworkOverview/StatCards/index.jsx
+++ b/src/v2/components/Dashboard/NetworkOverview/StatCards/index.jsx
@@ -48,7 +48,7 @@ const StatCards = () => {
           <Tooltip
             classes={{tooltip: classes.tooltip}}
             placement="top"
-            title={globalStats['!entLastLeader']}
+            title={globalStats['!entLastLeader'] || ''}
           >
             <Link
               className={classes.leader}

--- a/src/v2/stores/nodes.js
+++ b/src/v2/stores/nodes.js
@@ -48,16 +48,25 @@ class Store {
   });
 
   get mapMarkers() {
-    return compose(
-      map(({nodePubkey: pubkey, tpu: gossip, coordinates, identity}) => ({
-        pubkey,
-        gossip,
-        coordinates,
-        name: (identity && identity.name) || identity.pubkey,
-        avatarUrl: (identity && identity.avatarUrl) || '',
-      })),
-      filter({what: 'Validator'}),
-    )(this.network);
+    if (!this.network || !this.network.length) {
+      return [];
+    }
+
+    try {
+      return compose(
+        map(({nodePubkey: pubkey, tpu: gossip, coordinates, identity}) => ({
+          pubkey,
+          gossip,
+          coordinates,
+          name: (identity && identity.name) || identity.pubkey,
+          avatarUrl: (identity && identity.avatarUrl) || '',
+        })),
+        filter({what: 'Validator'}),
+      )(this.network);
+    } catch (e) {
+      console.error('mapMarkers()', e);
+      return [];
+    }
   }
 
   get validators() {


### PR DESCRIPTION
PROBLEM:

* white screen on beta explorer, seems related to map markers
* react warning on tooltip - title attribute not provided

SOLUTION:

* robustify map marker computation
* provide default empty string for tooltip
