### PR TITLE
feat: enable blocks and transactions tabs

### DIFF
--- a/src/v2/components/NavBar/index.jsx
+++ b/src/v2/components/NavBar/index.jsx
@@ -78,15 +78,13 @@ const NavBar = ({
       title: 'tour de sol',
     }),
     {
+      link: 'blocks',
+    },
+    {
       link: 'transactions',
-      disabled: true,
     },
     {
       link: 'programs',
-      disabled: true,
-    },
-    {
-      link: 'blocks',
       disabled: true,
     },
     {


### PR DESCRIPTION
enabled blocks and transactions tabs and regrouped them a little. programs tab does not show anything and still need to be styled so i kept it disabled. favs also disabled for now