### PR TITLE
fix: offset adding

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -645,8 +645,8 @@ async function getClusterInfo() {
     let offsetLat = randomOffset(ip);
     let offsetLng = randomOffset(tpu);
 
-    let lat = ((ll && ll[0]) || DEFAULT_LAT) + offsetLat;
-    let lng = ((ll && ll[1]) || DEFAULT_LNG) + offsetLng;
+    let lat = +((ll && ll[0]) || DEFAULT_LAT) + offsetLat;
+    let lng = +((ll && ll[1]) || DEFAULT_LNG) + offsetLng;
 
     network[pubkey] = Object.assign(network[pubkey] || {}, {
       online: true,


### PR DESCRIPTION
with new geo solution coords are strings and as result an issue with concatenation of string and number produces next invalid result:

(-26.04450-0.00937225796214989, 28.01870-0.01101979164350269)

Fix is to convert to number coords.  