### PR TITLE
feat: diable @material-ui Avatar fallback icon

### DIFF
--- a/src/v2/components/UI/Avatar/index.jsx
+++ b/src/v2/components/UI/Avatar/index.jsx
@@ -43,7 +43,15 @@ const Avatar = ({
     backgroundPosition: `${x}px ${y}px`,
   };
 
-  return <BaseAvatar src={avatarUrl} style={avatarStyle} />;
+  return (
+    <BaseAvatar src={avatarUrl} style={avatarStyle}>
+      {
+        // explicit 'empty child' node to disable Avatar fallback
+        // see : https://github.com/mui-org/material-ui/pull/18711
+        ' '
+      }
+    </BaseAvatar>
+  );
 };
 
 export default observer(Avatar);


### PR DESCRIPTION
Problem

* a recent version of material-ui includes a fallback icon for Avatar

Solution

* pass an "empty child" node to disable fallback icon